### PR TITLE
Fix: Correct Vercel deployment and remove boilerplate

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,14 +1,5 @@
 {
-  "version": 2,
-  "builds": [
-    {
-      "src": "package.json",
-      "use": "@vercel/static-build",
-      "config": { "distDir": "dist" }
-    }
-  ],
-  "routes": [
-    { "src": "/_next/static/(.*)", "dest": "/_next/static/$1" },
-    { "src": "/(.*)", "dest": "/index.html" }
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
## 📜 Description

This PR addresses two main items:

1.  **Critical Fix:** It corrects a misconfiguration in `vercel.json` that was causing the deployed application to fail with a blank white screen and a MIME type error.
2.  **Code Cleanup:** It removes the unused boilerplate components, views, and icons from the default Vue project setup.

## 🎟️ Related Issue

<!-- Link to the issue that this PR is resolving. -->
Closes #1, Closes #2


## 💡 Changes Made

#### Vercel Configuration
- Modified `vercel.json` to use the correct `rewrites` property instead of `routes`. This ensures that the application's JavaScript and CSS assets are served correctly while still supporting SPA routing.

#### Boilerplate Cleanup
- Removed `HelloWorld.vue`, `TheWelcome.vue`, and `WelcomeItem.vue` from `src/components`.
- Removed the entire `src/components/icons` directory.
- Removed the default `AboutView.vue` and its corresponding route.
- Cleaned up leftover imports in `App.vue`.

## ✅ How to Test

<!-- Please provide clear, step-by-step instructions for the reviewer to test your changes. -->
1. **Check the Vercel deployment preview link** attached to this Pull Request.
2. **Verify:** The application now loads correctly and does not show a blank white screen.
3. **Verify:** You can navigate from the home page to a chapter view without any errors in the browser's developer console.

## 📸 Screenshots / GIFs

<!-- If your PR includes any UI changes, please provide a screenshot or a short GIF. -->

| Before (Broken) | After (Fixed) |
| --- | --- |
| ![Blank White Screen](https://i.imgur.com/K12345.png) | ![Working App](https://i.imgur.com/ABCDEFG.png) |

*(Suggestion: Take a screenshot of the working app from the Vercel preview link and replace the "After" URL to make this PR even better!)*

## 📝 Checklist

- [x] My code follows the project's style guidelines.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings.